### PR TITLE
fixed not existing PINITSEQ macro in the sequence comment for evg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,17 @@ O.*/
 html/
 rtf
 *.local
+.DS_Store
+
+#documentation output
+epics-*
+*.pdf
+#*.aux
+#*.log
+#*.nav
+#*.tex
+#*.toc
+#*.vrb
 
 envPaths
 .project

--- a/evgMrmApp/Db/evgSoftSeq.template
+++ b/evgMrmApp/Db/evgSoftSeq.template
@@ -1,5 +1,5 @@
 # linked from mrmSoftSeq.template
-# $(PINITSEQ)Cont-FOut_
+# $ (PINITSEQ)Cont-FOut_
 record(fanout, "$(PTRIGSRC)Init-FOut_") {
     field( LNK1, "$(P)TrigSrc-Sel")
 }


### PR DESCRIPTION
- fixed not existing PINITSEQ macro in the sequence comment for evg
- .gitignore the doc files